### PR TITLE
Fix automatically recreating proxy service and Add new Openshift Spec params to CRDs in helm repo.

### DIFF
--- a/deploy/crds/wavefront_v1alpha1_wavefrontcollector_crd.yaml
+++ b/deploy/crds/wavefront_v1alpha1_wavefrontcollector_crd.yaml
@@ -56,6 +56,9 @@ spec:
             image:
               description: Defaults to wavefronthq/wavefront-kubernetes-collector:latest
               type: string
+            openshift:
+              description: Set to true when running collector in Openshift platform.
+              type: boolean
             resources:
               description: Compute resources required by the Collector containers.
               type: object
@@ -64,12 +67,9 @@ spec:
               items:
                 type: object
               type: array
-            openshift:
-              description:  Set to true when running collector in Openshift platform.
-              type: boolean
             useOpenshiftDefaultConfig:
-              description:  If set to true, Collector will use default config bundled in the image
-                else it will use the config from ConfigName.
+              description: If set to true, Collector will use default config bundled
+                in the image else it will use the config from ConfigName.
               type: boolean
           type: object
         status:

--- a/deploy/crds/wavefront_v1alpha1_wavefrontproxy_crd.yaml
+++ b/deploy/crds/wavefront_v1alpha1_wavefrontproxy_crd.yaml
@@ -62,6 +62,9 @@ spec:
                 Wavefront data format. This is usually port 2878 by default.
               format: int32
               type: integer
+            openshift:
+              description: Set to true when running proxy in Openshift platform.
+              type: boolean
             preprocessor:
               description: The name of the config map providing the preprocessor rules
                 for the Wavefront proxy.
@@ -70,6 +73,10 @@ spec:
               description: The no. of replicas for Wavefront Proxy. Defaults to 1
               format: int32
               type: integer
+            storageClaimName:
+              description: The name of the storage claim to be used for creating proxy
+                buffers directory. This is applicable only in an Openshift environment.
+              type: string
             token:
               description: Wavefront API Token.
               type: string
@@ -97,13 +104,6 @@ spec:
                 to none. This is usually 9411
               format: int32
               type: integer
-            openshift:
-              description:  This need to be set to true when running proxy in Openshift platform.
-              type: boolean
-            storageClaimName:
-              description: The name of the storage claim to be used for creating proxy buffers directory.
-                This is applicable only in an Openshift environment.
-              type: string  
           required:
           - url
           - token

--- a/install/wavefront-operator/templates/collector-crd.yaml
+++ b/install/wavefront-operator/templates/collector-crd.yaml
@@ -58,6 +58,9 @@ spec:
             image:
               description: Defaults to wavefronthq/wavefront-kubernetes-collector:latest
               type: string
+            openshift:
+              description: Set to true when running collector in Openshift platform.
+              type: boolean
             resources:
               description: Compute resources required by the Collector containers.
               type: object
@@ -66,6 +69,10 @@ spec:
               items:
                 type: object
               type: array
+            useOpenshiftDefaultConfig:
+              description: If set to true, Collector will use default config bundled
+                in the image else it will use the config from ConfigName.
+              type: boolean
           type: object
         status:
           properties:

--- a/install/wavefront-operator/templates/proxy-crd.yaml
+++ b/install/wavefront-operator/templates/proxy-crd.yaml
@@ -42,7 +42,7 @@ spec:
               type: string
             enableAutoUpgrade:
               description: If set to true, Proxy pods will be upgraded automatically
-                in case new minor upgrade version is available. For pinning proxy
+                in case new minor upgrade version is available. For pinning Proxy
                 to a specific version, you will need to set this option to false.
                 We support only minor version Auto Upgrades.
               type: boolean
@@ -64,6 +64,9 @@ spec:
                 Wavefront data format. This is usually port 2878 by default.
               format: int32
               type: integer
+            openshift:
+              description: Set to true when running proxy in Openshift platform.
+              type: boolean
             preprocessor:
               description: The name of the config map providing the preprocessor rules
                 for the Wavefront proxy.
@@ -72,6 +75,10 @@ spec:
               description: The no. of replicas for Wavefront Proxy. Defaults to 1
               format: int32
               type: integer
+            storageClaimName:
+              description: The name of the storage claim to be used for creating proxy
+                buffers directory. This is applicable only in an Openshift environment.
+              type: string
             token:
               description: Wavefront API Token.
               type: string

--- a/pkg/apis/wavefront/v1alpha1/wavefrontcollector_types.go
+++ b/pkg/apis/wavefront/v1alpha1/wavefrontcollector_types.go
@@ -44,7 +44,7 @@ type WavefrontCollectorSpec struct {
 	Openshift bool `json:"openshift,omitempty"`
 
 	// If set to true, Collector will use default config bundled in the image
-	// else it will use the config from ConfigName
+	// else it will use the config from ConfigName.
 	UseOpenshiftDefaultConfig bool `json:"useOpenshiftDefaultConfig,omitempty"`
 }
 

--- a/pkg/apis/wavefront/v1alpha1/wavefrontproxy_types.go
+++ b/pkg/apis/wavefront/v1alpha1/wavefrontproxy_types.go
@@ -74,7 +74,7 @@ type WavefrontProxySpec struct {
 	Openshift bool `json:"openshift,omitempty"`
 
 	// The name of the storage claim to be used for creating proxy buffers directory.
-	// This is applicable only in an Openshift environment."
+	// This is applicable only in an Openshift environment.
 	StorageClaimName string `json:"storageClaimName,omitempty"`
 }
 

--- a/pkg/apis/wavefront/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/wavefront/v1alpha1/zz_generated.openapi.go
@@ -25,7 +25,6 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontCollector(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WavefrontCollector is the Schema for the wavefrontcollectors API",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -69,7 +68,6 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontCollectorSpec(ref common.Refere
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WavefrontCollectorSpec defines the desired state of WavefrontCollector",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
@@ -147,7 +145,7 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontCollectorSpec(ref common.Refere
 					},
 					"useOpenshiftDefaultConfig": {
 						SchemaProps: spec.SchemaProps{
-							Description: "If set to true, Collector will use default config bundled in the image else it will use the config from ConfigName",
+							Description: "If set to true, Collector will use default config bundled in the image else it will use the config from ConfigName.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -165,7 +163,6 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontCollectorStatus(ref common.Refe
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WavefrontCollectorStatus defines the observed state of WavefrontCollector",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"version": {
 						SchemaProps: spec.SchemaProps{
@@ -191,7 +188,6 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontProxy(ref common.ReferenceCallb
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WavefrontProxy is the Schema for the wavefrontproxies API",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -235,7 +231,6 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontProxySpec(ref common.ReferenceC
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WavefrontProxySpec defines the desired state of WavefrontProxy",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"image": {
 						SchemaProps: spec.SchemaProps{
@@ -351,7 +346,7 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontProxySpec(ref common.ReferenceC
 					},
 					"storageClaimName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The name of the storage claim to be used for creating proxy buffers directory. This is applicable only in an Openshift environment.\"",
+							Description: "The name of the storage claim to be used for creating proxy buffers directory. This is applicable only in an Openshift environment.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -360,6 +355,7 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontProxySpec(ref common.ReferenceC
 				Required: []string{"url", "token"},
 			},
 		},
+		Dependencies: []string{},
 	}
 }
 
@@ -368,7 +364,6 @@ func schema_pkg_apis_wavefront_v1alpha1_WavefrontProxyStatus(ref common.Referenc
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "WavefrontProxyStatus defines the observed state of WavefrontProxy",
-				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"version": {
 						SchemaProps: spec.SchemaProps{


### PR DESCRIPTION
Fixed the case of -  Deleting proxy service -> should automatically create a new proxy service.

Added the openshift specific Spec parameters to CRD's under install/templates/. for helm. 