### PR TITLE
Improvements for logging, external proxy doc and default metrics ports

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -28,7 +28,7 @@ The required options for the chart are:
 
 To deploy a release named "test" into a namespace "test-ns":
 ```
-helm install --name test wavefront/wavefront-operator --set wavefront.url=https://YOUR_CLUSTER.wavefront.com,wavefront.token=YOUR_API_TOKEN,clusterName=YOUR_CLUSTER_NAME --namespace test-ns
+helm install --name test wavefront/wavefront-operator --set wavefront.url=https://YOUR_CLUSTER.wavefront.com,wavefront.token=YOUR_API_TOKEN,clusterName=YOUR_CLUSTER_NAME --namespace test-namespace
 ```
 
 ### Troubleshooting:
@@ -51,10 +51,17 @@ To uninstall/delete a deployed chart named "test":
 helm delete test --purge
 ```
 
-CRDs created by this chart are not removed as part of helm delete. To remove the CRDs:
+CRDs and namespaces created by this chart are not removed as part of helm delete.
+
+To remove the CRDs:
 ```
 kubectl delete crd wavefrontcollectors.wavefront.com
 kubectl delete crd wavefrontproxies.wavefront.com
+```
+
+To remove the namespace:
+```
+kubectl delete namespace test-namespace
 ```
 
 ## Development

--- a/install/wavefront-operator/README.md
+++ b/install/wavefront-operator/README.md
@@ -42,8 +42,15 @@ To uninstall/delete a deployed chart release:
 helm delete <release-name> --purge
 ```
 
-CRDs created by this chart are not removed as part of helm delete. To remove the CRDs:
+CRDs and namespaces created by this chart are not removed as part of helm delete.
+
+To remove the CRDs:
 ```
 kubectl delete crd wavefrontcollectors.wavefront.com
 kubectl delete crd wavefrontproxies.wavefront.com
+```
+
+To remove the namespace:
+```
+kubectl delete namespace test-namespace
 ```

--- a/install/wavefront-operator/templates/collector-config.yaml
+++ b/install/wavefront-operator/templates/collector-config.yaml
@@ -14,7 +14,11 @@ data:
     {{- if .Values.collector.proxyAddress }}
     - proxyAddress: {{ .Values.collector.proxyAddress }}
     {{- else }}
+    {{- if .Values.proxy.metricPort }}
     - proxyAddress: {{ template "wavefront-operator.proxy.fullname" . }}:{{ .Values.proxy.metricPort }}
+    {{- else }}
+    - proxyAddress: {{ template "wavefront-operator.proxy.fullname" . }}:2878
+    {{- end }}
     {{- end }}
     {{- else }}
     - server: {{ .Values.wavefront.url }}

--- a/install/wavefront-operator/values.yaml
+++ b/install/wavefront-operator/values.yaml
@@ -6,7 +6,7 @@
 clusterName: KUBERNETES_CLUSTER_NAME
 
 
-## Wavefront URL (cluster) and API Token
+## Wavefront URL (cluster) and API Token. (If using an external proxy the url and token are not required.)
 ## Required
 wavefront:
   url: https://YOUR_CLUSTER.wavefront.com
@@ -18,7 +18,7 @@ operator:
   enabled: true
   image:
     repository: wavefronthq/wavefront-operator-for-kubernetes
-    tag: 0.1.0-rc2
+    tag: 0.1.0-rc3
     pullPolicy: IfNotPresent
 
 
@@ -63,12 +63,13 @@ collector:
 
   ## If set to true, metrics will be sent to Wavefront via a Wavefront Proxy.
   ## When true you must either specify a value for `collector.proxyAddress` or set `proxy.enabled` to true
-  ## If set to false, metrics will be sent to Wavefront via the Direct Ingestion API
+  ## If set to false, metrics will be sent to Wavefront via the Direct Ingestion API.
   useProxy: true
 
   ## Can be used to specify a specific address for the Wavefront Proxy
   ## The proxy can be anywhere network reachable including outside of the cluster
-  ## Required if `collector.useProxy` is true and `proxy.enabled` is false
+  ## Required when using an External Proxy.
+  ## (To use an External Proxy you should set `collector.useProxy` to true and `proxy.enabled` to false)
   # proxyAddress: wavefront-proxy:2878
 
   ## If set to true Kubernetes API Server will also be scraped for metrics (default false)
@@ -149,8 +150,8 @@ proxy:
     tag: 4.38
 
   ## The port number the proxy will listen on for metrics in Wavefront data format.
-  ## This is usually 2878
-  metricPort: 2878
+  ## This is by default 2878
+  # metricPort: 2878
 
   ## The no. of replicas for Wavefront Proxy. Defaults to 1
   # size: 3
@@ -186,11 +187,11 @@ proxy:
 
   ## The name of the config map providing the advanced configurations for the Wavefront proxy.
   ## This is synonymous to the wavefront.conf file at https://docs.wavefront.com/proxies_configuring.html#paths
-  #	advanced:
+  # advanced: advanced-config
 
   ## The comma separated list of ports that need to be opened on Proxy Pod and Services.
   ## Needs to be explicitly specified when using "Advanced" configuration.
-  #	additionalPorts: 2879, 30001
+  # additionalPorts: 2879, 30001
 
   ## If set to true, Proxy pods will be upgraded automatically in case new minor upgrade version is available.
   ## For pinning Proxy to a specific version, you will need to set this option to false.

--- a/pkg/controller/util/upgrade.go
+++ b/pkg/controller/util/upgrade.go
@@ -21,7 +21,7 @@ const (
 )
 
 // GetLatestVersion checks for auto upgrade eligibility and returns the latest minor version as applicable.
-func GetLatestVersion(crImage string, enableAutoUpgrade bool, reqLogger logr.Logger) (string, error) {
+func GetLatestVersion(crImage string, reqLogger logr.Logger) (string, error) {
 	imgSlice := strings.Split(crImage, ":")
 	crImageName := imgSlice[0]
 	currentVersion := imgSlice[1]
@@ -33,12 +33,6 @@ func GetLatestVersion(crImage string, enableAutoUpgrade bool, reqLogger logr.Log
 			reqLogger.Info("Auto Upgrade not supported,", "Cause :: Not an offically supported wavefronthq Docker Hub Image.", crImage)
 			return "", nil
 		}
-	}
-
-	// Auto Upgrade support
-	if !enableAutoUpgrade {
-		reqLogger.Info("Auto Upgrade not supported,", " Cause :: enableAutoUpgrade is set to ", enableAutoUpgrade)
-		return currentVersion, nil
 	}
 
 	// "latest" effectively renders auto upgrade useless.

--- a/pkg/controller/util/upgrade_test.go
+++ b/pkg/controller/util/upgrade_test.go
@@ -18,7 +18,7 @@ func TestProxyValidUpgrade(t *testing.T) {
 	v := "5.1"
 	i := DockerHubProxy + v
 	semV, _ := semver.NewVersion(v)
-	returnVer, err := GetLatestVersion(i, true, reqLogger)
+	returnVer, err := GetLatestVersion(i, reqLogger)
 	if err != nil {
 		t.Error("Failed to get latest version :: ", err)
 	}
@@ -36,7 +36,7 @@ func TestCollectorValidUpgrade(t *testing.T) {
 	v := "1.0.0"
 	i := DockerHubCollector + v
 	semV, _ := semver.NewVersion(v)
-	returnVer, err := GetLatestVersion(i, true, reqLogger)
+	returnVer, err := GetLatestVersion(i, reqLogger)
 	if err != nil {
 		t.Error("Failed to get latest version :: ", err)
 	}
@@ -53,7 +53,7 @@ func TestImageLatest(t *testing.T) {
 	// Proxy
 	v := "latest"
 	i := DockerHubProxy + v
-	returnVer, err := GetLatestVersion(i, true, reqLogger)
+	returnVer, err := GetLatestVersion(i, reqLogger)
 	if err != nil {
 		t.Error("Failed to get latest version :: ", err)
 	}
@@ -64,30 +64,12 @@ func TestImageLatest(t *testing.T) {
 	}
 }
 
-func TestUpgradeDisabled(t *testing.T) {
-	reqLogger := logf.Log.WithName("Upgrade_Test")
-	// Proxy
-	v := "2.1"
-	i := DockerHubProxy + v
-	semV, _ := semver.NewVersion(v)
-	returnVer, err := GetLatestVersion(i, false, reqLogger)
-	if err != nil {
-		t.Error("Failed to get latest version :: ", err)
-	}
-	returnSemV, _ := semver.NewVersion(returnVer)
-
-	if !returnSemV.Equal(semV) {
-		t.Error("Error :: Expected returned version for Proxy Upgrade : ", returnVer,
-			" to be same as input version : ", v)
-	}
-}
-
 func TestNonDockerImage(t *testing.T) {
 	reqLogger := logf.Log.WithName("Upgrade_Test")
 	// Collector
 	v := "5.1"
 	i := OpenShiftProxy + v
-	returnVer, err := GetLatestVersion(i, true, reqLogger)
+	returnVer, err := GetLatestVersion(i, reqLogger)
 	if err != nil || returnVer != "" {
 		t.Error("Expected empty version to be returned since Auto upgrade is not supported for OpenShift Images :: ")
 	}

--- a/pkg/controller/wavefrontcollector/wavefrontcollector_controller.go
+++ b/pkg/controller/wavefrontcollector/wavefrontcollector_controller.go
@@ -136,12 +136,14 @@ func getLatestCollector(reqLogger logr.Logger, instance *wavefrontv1alpha1.Wavef
 	// Validate Image format and Auto Upgrade.
 	if len(imgSlice) == 2 {
 		instance.Status.Version = imgSlice[1]
-		finalVer, err := util.GetLatestVersion(instance.Spec.Image, instance.Spec.EnableAutoUpgrade, reqLogger)
-		if err == nil && finalVer != "" {
-			instance.Status.Version = finalVer
-			instance.Spec.Image = imgSlice[0] + ":" + finalVer
-		} else if err != nil {
-			reqLogger.Error(err, "Auto Upgrade Error.")
+		if instance.Spec.EnableAutoUpgrade {
+			finalVer, err := util.GetLatestVersion(instance.Spec.Image, reqLogger)
+			if err == nil && finalVer != "" {
+				instance.Status.Version = finalVer
+				instance.Spec.Image = imgSlice[0] + ":" + finalVer
+			} else if err != nil {
+				reqLogger.Error(err, "Auto Upgrade Error.")
+			}
 		}
 	} else {
 		reqLogger.Info("Cannot update CR's Status.version", "Un-recognized format for CR Image", instance.Spec.Image)

--- a/pkg/controller/wavefrontproxy/proxyspec_internal.go
+++ b/pkg/controller/wavefrontproxy/proxyspec_internal.go
@@ -63,7 +63,7 @@ func (ip *InternalWavefrontProxy) initialize(instance *wfv1.WavefrontProxy, reqL
 	if ip.instance.Spec.Image == "" {
 		ip.instance.Spec.Image = defaultImage
 	}
-	
+
 	imgSlice := strings.Split(ip.instance.Spec.Image, ":")
 	// Validate Image format and Auto Upgrade.
 	if len(imgSlice) == 2 {

--- a/pkg/controller/wavefrontproxy/proxyspec_internal.go
+++ b/pkg/controller/wavefrontproxy/proxyspec_internal.go
@@ -64,16 +64,19 @@ func (ip *InternalWavefrontProxy) initialize(instance *wfv1.WavefrontProxy, reqL
 		ip.instance.Spec.Image = defaultImage
 	}
 
+
 	imgSlice := strings.Split(ip.instance.Spec.Image, ":")
 	// Validate Image format and Auto Upgrade.
 	if len(imgSlice) == 2 {
 		ip.instance.Status.Version = imgSlice[1]
-		finalVer, err := util.GetLatestVersion(ip.instance.Spec.Image, ip.instance.Spec.EnableAutoUpgrade, reqLogger)
-		if err == nil && finalVer != "" {
-			ip.instance.Status.Version = finalVer
-			ip.instance.Spec.Image = imgSlice[0] + ":" + finalVer
-		} else if err != nil {
-			reqLogger.Error(err, "Auto Upgrade Error.")
+		if ip.instance.Spec.EnableAutoUpgrade {
+			finalVer, err := util.GetLatestVersion(ip.instance.Spec.Image, reqLogger)
+			if err == nil && finalVer != "" {
+				ip.instance.Status.Version = finalVer
+				ip.instance.Spec.Image = imgSlice[0] + ":" + finalVer
+			} else if err != nil {
+				reqLogger.Error(err, "Auto Upgrade Error.")
+			}
 		}
 	} else {
 		reqLogger.Info("Cannot update CR's Status.version", "Un-recognized format for CR Image", instance.Spec.Image)

--- a/pkg/controller/wavefrontproxy/proxyspec_internal.go
+++ b/pkg/controller/wavefrontproxy/proxyspec_internal.go
@@ -63,8 +63,7 @@ func (ip *InternalWavefrontProxy) initialize(instance *wfv1.WavefrontProxy, reqL
 	if ip.instance.Spec.Image == "" {
 		ip.instance.Spec.Image = defaultImage
 	}
-
-
+	
 	imgSlice := strings.Split(ip.instance.Spec.Image, ":")
 	// Validate Image format and Auto Upgrade.
 	if len(imgSlice) == 2 {


### PR DESCRIPTION
1. Reduce noise in upgrade logs when auto upgrade is disabled.
2. make 2878 as default metrics port and optional to be specified in helm values.yaml
3. Improve doc for external proxy.